### PR TITLE
feat: v4.5.0 — custom point names, side effects reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 4.5.0 - 2026-03-04
+
+### Aggiunto
+- **Nomi personalizzati nei record**: Quando si crea un'iniezione, il `pointLabel` ora include il nome custom del punto (es. "Coscia Dx · ABC (3)") con il numero originale tra parentesi per riferimento.
+- **Promemoria 1 minuto**: Notifica urgente 1 minuto prima dell'iniezione programmata, in aggiunta al promemoria configurabile esistente.
+- **Promemoria effetti collaterali**: Notifica configurabile (default 4h) dopo il completamento dell'iniezione per registrare eventuali effetti collaterali.
+- **Dialog effetti collaterali ritardato**: Gli effetti collaterali vengono chiesti alla registrazione dell'iniezione successiva, non più immediatamente.
+- **Export CSV con label**: Il CSV ora include la colonna `label` con il nome personalizzato del punto.
+
+### Migliorato
+- **Import CSV retrocompatibile**: Supporta sia il formato a 4 colonne (vecchio) che a 5 colonne (con label).
+- **Report PDF con nomi custom**: La colonna "Punto" nel report PDF ora mostra il label completo (inclusi nomi personalizzati).
+
+### Corretto
+- **Nomi custom non usati**: I nomi personalizzati dei punti (da ZonePointsEditor) non venivano propagati alla creazione dell'iniezione, mostrando sempre il formato default nel calendario, storico e notifiche.
+
 ## 4.4.0 - 2026-03-04
 
 ### Aggiunto

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -684,6 +684,16 @@ class AppDatabase extends _$AppDatabase {
   Future<Injection?> getInjectionById(int id) =>
       (select(injections)..where((i) => i.id.equals(id))).getSingleOrNull();
 
+  /// Restituisce l'ultima iniezione completata senza effetti collaterali registrati
+  Future<Injection?> getLastCompletedInjectionWithoutSideEffects() =>
+      (select(injections)
+            ..where(
+              (i) => i.status.equals('completed') & i.sideEffects.equals(''),
+            )
+            ..orderBy([(i) => OrderingTerm.desc(i.completedAt)])
+            ..limit(1))
+          .getSingleOrNull();
+
   // --- Utilities ---
   Future<void> deleteAllData() async {
     await delete(injections).go();

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -124,17 +124,22 @@ class ExportService {
   Future<void> exportToCsv(List<dynamic> injections) async {
     final buffer = StringBuffer();
 
-    // Header semplice
-    buffer.writeln('data,zona,punto,stato');
+    // Header con label per mostrare nomi custom + default
+    buffer.writeln('data,zona,punto,label,stato');
 
-    // Data rows - formato semplice
+    // Data rows - formato con label personalizzato
     for (final inj in injections) {
       if (inj is Injection) {
         final date = inj.completedAt ?? inj.scheduledAt;
+        // Escape pointLabel per CSV (potrebbe contenere virgole)
+        final escapedLabel = inj.pointLabel.contains(',')
+            ? '"${inj.pointLabel}"'
+            : inj.pointLabel;
         buffer.writeln([
           DateFormat('yyyy-MM-dd HH:mm').format(date),
           inj.pointCode.split('-').first, // Zone code (es. CD, CS, BD, BS, AD, AS, GD, GS)
           inj.pointNumber,
+          escapedLabel,
           inj.status,
         ].join(','));
       }

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -21,11 +21,12 @@ class ImportResult {
 
 /// Service per importare dati da CSV
 ///
-/// Formato CSV supportato:
+/// Formato CSV supportato (4 o 5 colonne):
 /// ```
 /// data,zona,punto,stato
+/// data,zona,punto,label,stato
 /// 2024-07-15 20:00,CD,3,completed
-/// 2024-07-17 20:00,CS,1,completed
+/// 2024-07-15 20:00,CD,3,Coscia Dx · ABC (3),completed
 /// ```
 ///
 /// Zone code: CD, CS, BD, BS, AD, AS, GD, GS
@@ -134,8 +135,19 @@ class ImportService {
         return _ParseResult.failure('Numero punto non valido: ${parts[2]}');
       }
 
-      // Parse status
-      final status = parts[3].toLowerCase();
+      // Supporta sia formato a 4 colonne (data,zona,punto,stato)
+      // che a 5 colonne (data,zona,punto,label,stato)
+      final String status;
+      final String? customLabel;
+      if (parts.length >= 5 && !_validStatuses.contains(parts[3].toLowerCase())) {
+        // 5-column format: label is at index 3, status at index 4
+        customLabel = parts[3];
+        status = parts[4].toLowerCase();
+      } else {
+        // 4-column format: status at index 3
+        customLabel = null;
+        status = parts[3].toLowerCase();
+      }
       if (!_validStatuses.contains(status)) {
         return _ParseResult.failure(
           'Stato non valido: $status (usa: completed, scheduled, skipped, delayed, missed)',
@@ -149,11 +161,14 @@ class ImportService {
       }
 
       // Insert injection
+      final pointLabel = customLabel?.isNotEmpty == true
+          ? customLabel!
+          : '${zoneInfo.name} · $pointNumber';
       await db.insertInjection(InjectionsCompanion.insert(
         zoneId: zoneInfo.id,
         pointNumber: pointNumber,
         pointCode: '$zoneCode-$pointNumber',
-        pointLabel: '${zoneInfo.name} · $pointNumber',
+        pointLabel: pointLabel,
         scheduledAt: date,
         completedAt: Value(completedAt),
         status: Value(status),

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -167,10 +167,96 @@ class NotificationService {
     );
   }
 
+  /// Schedule a 1-minute pre-injection reminder
+  Future<void> scheduleOneMinuteReminder({
+    required int id,
+    required DateTime scheduledTime,
+    required String pointLabel,
+  }) async {
+    final reminderTime = scheduledTime.subtract(const Duration(minutes: 1));
+
+    // Don't schedule if reminder time is in the past
+    if (reminderTime.isBefore(DateTime.now())) return;
+
+    const androidDetails = AndroidNotificationDetails(
+      'injection_reminders',
+      'Promemoria iniezioni',
+      channelDescription: 'Notifiche per le iniezioni programmate',
+      importance: Importance.max,
+      priority: Priority.max,
+      icon: '@mipmap/ic_launcher',
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notifications.zonedSchedule(
+      id + 20000, // Offset to avoid ID conflicts
+      'Iniezione tra 1 minuto',
+      'Preparati: $pointLabel',
+      tz.TZDateTime.from(reminderTime, tz.local),
+      details,
+      androidScheduleMode: await _androidScheduleMode(),
+    );
+  }
+
+  /// Schedule a side effects reminder after injection completion
+  Future<void> scheduleSideEffectsReminder({
+    required int id,
+    required DateTime completedAt,
+    required String pointLabel,
+    int hoursAfter = 4,
+  }) async {
+    final reminderTime = completedAt.add(Duration(hours: hoursAfter));
+
+    // Don't schedule if reminder time is in the past
+    if (reminderTime.isBefore(DateTime.now())) return;
+
+    const androidDetails = AndroidNotificationDetails(
+      'side_effects_reminders',
+      'Promemoria effetti collaterali',
+      channelDescription: 'Notifiche per registrare effetti collaterali post-iniezione',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+      icon: '@mipmap/ic_launcher',
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notifications.zonedSchedule(
+      id + 30000, // Offset to avoid ID conflicts
+      'Come è andata l\'iniezione?',
+      'Registra eventuali effetti collaterali: $pointLabel',
+      tz.TZDateTime.from(reminderTime, tz.local),
+      details,
+      androidScheduleMode: await _androidScheduleMode(),
+      payload: 'side_effects:$id',
+    );
+  }
+
   /// Cancel a scheduled notification
   Future<void> cancelNotification(int id) async {
     await _notifications.cancel(id);
-    await _notifications.cancel(id + 10000); // Cancel missed dose reminder too
+    await _notifications.cancel(id + 10000); // Cancel missed dose reminder
+    await _notifications.cancel(id + 20000); // Cancel 1-minute reminder
+    await _notifications.cancel(id + 30000); // Cancel side effects reminder
   }
 
   /// Cancel all scheduled notifications
@@ -222,6 +308,13 @@ class NotificationService {
       scheduledTime: injection.scheduledAt,
       pointLabel: injection.pointLabel,
       minutesBefore: minutesBefore,
+    );
+
+    // Schedule 1-minute pre-injection reminder
+    await scheduleOneMinuteReminder(
+      id: id,
+      scheduledTime: injection.scheduledAt,
+      pointLabel: injection.pointLabel,
     );
 
     // Schedule missed dose reminder if enabled

--- a/lib/core/services/notification_settings_provider.dart
+++ b/lib/core/services/notification_settings_provider.dart
@@ -10,6 +10,7 @@ class NotificationSettings {
   final bool missedDoseReminder;
   final bool permissionsGranted;
   final int overdueGraceMinutes;
+  final int sideEffectsReminderHours;
 
   const NotificationSettings({
     this.enabled = true,
@@ -17,6 +18,7 @@ class NotificationSettings {
     this.missedDoseReminder = true,
     this.permissionsGranted = false,
     this.overdueGraceMinutes = 60,
+    this.sideEffectsReminderHours = 4,
   });
 
   NotificationSettings copyWith({
@@ -25,6 +27,7 @@ class NotificationSettings {
     bool? missedDoseReminder,
     bool? permissionsGranted,
     int? overdueGraceMinutes,
+    int? sideEffectsReminderHours,
   }) {
     return NotificationSettings(
       enabled: enabled ?? this.enabled,
@@ -32,6 +35,7 @@ class NotificationSettings {
       missedDoseReminder: missedDoseReminder ?? this.missedDoseReminder,
       permissionsGranted: permissionsGranted ?? this.permissionsGranted,
       overdueGraceMinutes: overdueGraceMinutes ?? this.overdueGraceMinutes,
+      sideEffectsReminderHours: sideEffectsReminderHours ?? this.sideEffectsReminderHours,
     );
   }
 }
@@ -43,6 +47,7 @@ class NotificationSettingsNotifier extends Notifier<NotificationSettings> {
   static const _keyMissedDose = 'notification_missed_dose';
   static const _keyPermissionsGranted = 'notification_permissions_granted';
   static const _keyOverdueGraceMinutes = 'notification_overdue_grace_minutes';
+  static const _keySideEffectsReminderHours = 'side_effects_reminder_hours';
 
   @override
   NotificationSettings build() {
@@ -58,6 +63,7 @@ class NotificationSettingsNotifier extends Notifier<NotificationSettings> {
       missedDoseReminder: prefs.getBool(_keyMissedDose) ?? true,
       permissionsGranted: prefs.getBool(_keyPermissionsGranted) ?? false,
       overdueGraceMinutes: prefs.getInt(_keyOverdueGraceMinutes) ?? 60,
+      sideEffectsReminderHours: prefs.getInt(_keySideEffectsReminderHours) ?? 4,
     );
   }
 
@@ -83,6 +89,12 @@ class NotificationSettingsNotifier extends Notifier<NotificationSettings> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_keyOverdueGraceMinutes, value);
     state = state.copyWith(overdueGraceMinutes: value);
+  }
+
+  Future<void> setSideEffectsReminderHours(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keySideEffectsReminderHours, value);
+    state = state.copyWith(sideEffectsReminderHours: value);
   }
 
   /// Request notification permissions

--- a/lib/core/services/pdf_report_service.dart
+++ b/lib/core/services/pdf_report_service.dart
@@ -375,8 +375,8 @@ class PdfReportService {
             border: pw.TableBorder.all(color: PdfColors.grey300),
             columnWidths: {
               0: const pw.FlexColumnWidth(2),
-              1: const pw.FlexColumnWidth(3),
-              2: const pw.FlexColumnWidth(1),
+              1: const pw.FlexColumnWidth(2),
+              2: const pw.FlexColumnWidth(3),
               3: const pw.FlexColumnWidth(2),
             },
             children: [
@@ -415,7 +415,7 @@ class PdfReportService {
                       zone != null ? '${zone.emoji} ${zone.displayName}' : 'Zona ${injection.zoneId}',
                       ttf,
                     ),
-                    _tableCell('${injection.pointNumber}', ttf),
+                    _tableCell(injection.pointLabel, ttf),
                     pw.Padding(
                       padding: const pw.EdgeInsets.all(6),
                       child: pw.Text(

--- a/lib/core/widgets/side_effects_dialog.dart
+++ b/lib/core/widgets/side_effects_dialog.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+/// Dialog riutilizzabile per registrare gli effetti collaterali di un'iniezione.
+/// Mostra una checklist con effetti comuni e un campo note opzionale.
+class SideEffectsDialog extends StatefulWidget {
+  const SideEffectsDialog({
+    super.key,
+    required this.injectionId,
+    required this.pointLabel,
+  });
+
+  final int injectionId;
+  final String pointLabel;
+
+  /// Mostra il dialog e restituisce la lista di effetti selezionati,
+  /// oppure null se l'utente annulla.
+  static Future<List<String>?> show(
+    BuildContext context, {
+    required int injectionId,
+    required String pointLabel,
+  }) {
+    return showDialog<List<String>>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => SideEffectsDialog(
+        injectionId: injectionId,
+        pointLabel: pointLabel,
+      ),
+    );
+  }
+
+  @override
+  State<SideEffectsDialog> createState() => _SideEffectsDialogState();
+}
+
+class _SideEffectsDialogState extends State<SideEffectsDialog> {
+  final _selectedEffects = <String>{};
+  final _notesController = TextEditingController();
+
+  static const _effects = [
+    'Rossore nel punto',
+    'Dolore locale',
+    'Stanchezza',
+    'Sintomi influenzali',
+    'Altro',
+  ];
+
+  @override
+  void dispose() {
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Come è andata l\'ultima iniezione?'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.pointLabel,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            ..._effects.map(
+              (effect) => CheckboxListTile(
+                title: Text(effect),
+                value: _selectedEffects.contains(effect),
+                onChanged: (value) {
+                  setState(() {
+                    if (value == true) {
+                      _selectedEffects.add(effect);
+                    } else {
+                      _selectedEffects.remove(effect);
+                    }
+                  });
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _notesController,
+              maxLines: 2,
+              decoration: const InputDecoration(
+                hintText: 'Note aggiuntive (opzionale)',
+                isDense: true,
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(const <String>[]),
+          child: const Text('Nessun effetto'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final effects = _selectedEffects.toList();
+            if (_notesController.text.isNotEmpty) {
+              effects.add('Note: ${_notesController.text}');
+            }
+            Navigator.of(context).pop(effects);
+          },
+          child: const Text('Salva'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/calendar/calendar_screen.dart
+++ b/lib/features/calendar/calendar_screen.dart
@@ -8,6 +8,8 @@ import '../../core/theme/app_colors.dart';
 import '../../core/database/app_database.dart' as db;
 import '../../app/router.dart';
 import '../../core/services/missed_injection_service.dart';
+import '../../core/services/notification_service.dart';
+import '../../core/services/notification_settings_provider.dart';
 import '../injection/injection_provider.dart';
 
 /// Calendar screen with injection schedule
@@ -462,6 +464,19 @@ class _InjectionCard extends ConsumerWidget {
           Navigator.pop(ctx);
           final repository = ref.read(injectionRepositoryProvider);
           await repository.completeInjection(injection.id);
+
+          // Schedula promemoria effetti collaterali
+          final notifSettings = ref.read(notificationSettingsProvider);
+          if (notifSettings.enabled && notifSettings.permissionsGranted) {
+            final notifId = injection.scheduledAt.millisecondsSinceEpoch ~/ 1000;
+            await NotificationService.instance.scheduleSideEffectsReminder(
+              id: notifId,
+              completedAt: DateTime.now(),
+              pointLabel: injection.pointLabel,
+              hoursAfter: notifSettings.sideEffectsReminderHours,
+            );
+          }
+
           ref.invalidate(injectionsProvider);
         },
         onSkip: () async {

--- a/lib/features/home/home_minimal_screen.dart
+++ b/lib/features/home/home_minimal_screen.dart
@@ -179,6 +179,7 @@ class _HomeMinimalScreenState extends ConsumerState<HomeMinimalScreen> {
                               scheduledInjectionId,
                               zone!,
                               pointNumber ?? 1,
+                              scheduledAt: displayDate,
                             );
                           } else {
                             _navigateToRecord(context, zone!.id, displayDate);
@@ -242,14 +243,20 @@ class _HomeMinimalScreenState extends ConsumerState<HomeMinimalScreen> {
     BuildContext context,
     int injectionId,
     model.BodyZone zone,
-    int pointNumber,
-  ) async {
+    int pointNumber, {
+    DateTime? scheduledAt,
+  }) async {
+    final repository = ref.read(injectionRepositoryProvider);
+    final resolvedLabel = await repository.resolvePointLabel(zone.id, pointNumber);
+
+    if (!context.mounted) return;
+
     final shouldComplete = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Conferma iniezione'),
         content: Text(
-          'Vuoi segnare ${zone.pointLabel(pointNumber)} come completata?',
+          'Vuoi segnare $resolvedLabel come completata?',
         ),
         actions: [
           TextButton(
@@ -265,9 +272,19 @@ class _HomeMinimalScreenState extends ConsumerState<HomeMinimalScreen> {
     );
 
     if (shouldComplete == true && context.mounted) {
-      final repository = ref.read(injectionRepositoryProvider);
-
       await repository.completeInjection(injectionId);
+
+      // Schedula promemoria effetti collaterali
+      final notifSettings = ref.read(notificationSettingsProvider);
+      if (notifSettings.enabled && notifSettings.permissionsGranted && scheduledAt != null) {
+        final notifId = scheduledAt.millisecondsSinceEpoch ~/ 1000;
+        await NotificationService.instance.scheduleSideEffectsReminder(
+          id: notifId,
+          completedAt: DateTime.now(),
+          pointLabel: resolvedLabel,
+          hoursAfter: notifSettings.sideEffectsReminderHours,
+        );
+      }
 
       // Refresh dei providers
       ref.invalidate(nextScheduledInjectionProvider);
@@ -278,7 +295,7 @@ class _HomeMinimalScreenState extends ConsumerState<HomeMinimalScreen> {
           ..clearSnackBars()
           ..showSnackBar(
             SnackBar(
-              content: Text('✓ ${zone.pointLabel(pointNumber)} completata!'),
+              content: Text('✓ $resolvedLabel completata!'),
               backgroundColor: Colors.green,
               duration: const Duration(seconds: 2),
             ),
@@ -356,11 +373,17 @@ class _HomeMinimalScreenState extends ConsumerState<HomeMinimalScreen> {
       );
       if (suggested == null) continue;
 
+      final resolvedLabel = await repository.resolvePointLabel(
+        suggested.zoneId,
+        suggested.pointNumber,
+      );
+
       final record = inj.InjectionRecord(
         zoneId: suggested.zoneId,
         pointNumber: suggested.pointNumber,
         scheduledAt: scheduledAt,
         status: inj.InjectionStatus.scheduled,
+        customPointLabel: resolvedLabel,
         createdAt: now,
         updatedAt: now,
       );

--- a/lib/features/injection/injection_repository.dart
+++ b/lib/features/injection/injection_repository.dart
@@ -11,6 +11,24 @@ class InjectionRepository {
 
   final AppDatabase _db;
 
+  /// Resolve the display label for a point, using custom names if configured.
+  /// Format: "ZoneName · CustomName (N)" when custom name exists,
+  /// otherwise "ZoneName · N" (default format).
+  Future<String> resolvePointLabel(int zoneId, int pointNumber) async {
+    final zone = await _db.getZoneById(zoneId);
+    if (zone == null) return 'Punto $pointNumber';
+
+    final zoneName = zone.customName?.isNotEmpty == true
+        ? zone.customName!
+        : zone.name;
+
+    final config = await _db.getPointConfig(zoneId, pointNumber);
+    if (config != null && config.customName.isNotEmpty) {
+      return '$zoneName · ${config.customName} ($pointNumber)';
+    }
+    return '$zoneName · $pointNumber';
+  }
+
   // ============================================================================
   // Injections
   // ============================================================================
@@ -103,6 +121,15 @@ class InjectionRepository {
       status: const Value('completed'),
       completedAt: Value(DateTime.now()),
       notes: Value(notes ?? ''),
+      sideEffects: Value(sideEffects.join(',')),
+      updatedAt: Value(DateTime.now()),
+    ));
+  }
+
+  /// Update side effects for an existing injection
+  Future<void> updateSideEffects(int injectionId, List<String> sideEffects) async {
+    await _db.updateInjection(InjectionsCompanion(
+      id: Value(injectionId),
       sideEffects: Value(sideEffects.join(',')),
       updatedAt: Value(DateTime.now()),
     ));
@@ -325,5 +352,10 @@ class InjectionRepository {
   /// Get injection by ID
   Future<Injection?> getInjectionById(int id) {
     return _db.getInjectionById(id);
+  }
+
+  /// Get last completed injection without side effects logged
+  Future<Injection?> getLastCompletedInjectionWithoutSideEffects() {
+    return _db.getLastCompletedInjectionWithoutSideEffects();
   }
 }

--- a/lib/features/injection/record_screen.dart
+++ b/lib/features/injection/record_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -11,6 +12,7 @@ import '../../models/injection_record.dart';
 import '../../core/services/notification_service.dart';
 import '../../core/services/notification_settings_provider.dart';
 import '../../core/ml/rotation_pattern_engine.dart';
+import '../../core/widgets/side_effects_dialog.dart';
 import 'injection_provider.dart';
 import 'zone_provider.dart';
 
@@ -36,8 +38,8 @@ class RecordInjectionScreen extends ConsumerStatefulWidget {
 
 class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
   final _notesController = TextEditingController();
-  final Set<String> _selectedSideEffects = {};
   bool _isLoading = false;
+  bool _sideEffectsChecked = false;
 
   BodyZone? _getZone(List<BodyZone> zones) {
     final zone = zones.where((z) => z.id == widget.zoneId).firstOrNull;
@@ -45,9 +47,36 @@ class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _checkPendingSideEffects();
+    });
+  }
+
+  @override
   void dispose() {
     _notesController.dispose();
     super.dispose();
+  }
+
+  Future<void> _checkPendingSideEffects() async {
+    if (_sideEffectsChecked) return;
+    _sideEffectsChecked = true;
+
+    final repository = ref.read(injectionRepositoryProvider);
+    final pending = await repository.getLastCompletedInjectionWithoutSideEffects();
+
+    if (pending != null && mounted) {
+      final effects = await SideEffectsDialog.show(
+        context,
+        injectionId: pending.id,
+        pointLabel: pending.pointLabel,
+      );
+      if (effects != null) {
+        await repository.updateSideEffects(pending.id, effects);
+      }
+    }
   }
 
   @override
@@ -159,37 +188,6 @@ class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
               ),
             ),
 
-            const SizedBox(height: 24),
-
-            // Side effects
-            Text(
-              'Effetti collaterali',
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-
-            ...[
-              'Rossore nel punto',
-              'Dolore locale',
-              'Stanchezza',
-              'Sintomi influenzali',
-              'Altro',
-            ].map((effect) => CheckboxListTile(
-              title: Text(effect),
-              value: _selectedSideEffects.contains(effect),
-              onChanged: (value) {
-                setState(() {
-                  if (value == true) {
-                    _selectedSideEffects.add(effect);
-                  } else {
-                    _selectedSideEffects.remove(effect);
-                  }
-                });
-              },
-              controlAffinity: ListTileControlAffinity.leading,
-              contentPadding: EdgeInsets.zero,
-            )),
-
             const SizedBox(height: 32),
 
             // Confirm button
@@ -227,6 +225,12 @@ class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
       // Questo permette all'utente di programmare e poi confermare
       const status = InjectionStatus.scheduled;
 
+      // Risolvi il label personalizzato (custom point/zone names)
+      final resolvedLabel = await repository.resolvePointLabel(
+        widget.zoneId,
+        widget.pointNumber,
+      );
+
       // Create injection record - sempre come "scheduled" inizialmente
       final record = InjectionRecord(
         zoneId: widget.zoneId,
@@ -235,7 +239,8 @@ class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
         completedAt: null, // Non completata ancora
         status: status,
         notes: _notesController.text.isNotEmpty ? _notesController.text : '',
-        sideEffects: _selectedSideEffects.toList(),
+        sideEffects: const [],
+        customPointLabel: resolvedLabel,
         createdAt: now,
         updatedAt: now,
       );
@@ -315,11 +320,23 @@ class _RecordInjectionScreenState extends ConsumerState<RecordInjectionScreen> {
 
           if (shouldComplete == true && mounted) {
             // Segna come completata
+            final completedAt = DateTime.now();
             final completedRecord = record.copyWith(
               status: InjectionStatus.completed,
-              completedAt: DateTime.now(),
+              completedAt: completedAt,
             );
             await repository.updateInjection(injectionId, completedRecord);
+
+            // Schedula promemoria effetti collaterali
+            if (notificationSettings.enabled && notificationSettings.permissionsGranted) {
+              final notifId = record.scheduledAt.millisecondsSinceEpoch ~/ 1000;
+              await NotificationService.instance.scheduleSideEffectsReminder(
+                id: notifId,
+                completedAt: completedAt,
+                pointLabel: record.pointLabel,
+                hoursAfter: notificationSettings.sideEffectsReminderHours,
+              );
+            }
 
             if (mounted) {
               ScaffoldMessenger.of(context)

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -183,6 +183,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                       .setMissedDoseReminder(value)
                 : null,
           ),
+          _SettingsTile(
+            title: 'Promemoria effetti collaterali',
+            trailing: Text('${notificationSettings.sideEffectsReminderHours} ore'),
+            onTap: () => _editSideEffectsReminderHours(
+              context,
+              notificationSettings.sideEffectsReminderHours,
+            ),
+          ),
           ListTile(
             title: const Text('Testa notifica'),
             subtitle: const Text('Visualizza un esempio di promemoria'),
@@ -611,6 +619,50 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ref
                     .read(notificationSettingsProvider.notifier)
                     .setMinutesBefore(value);
+              },
+              child: const Text('Salva'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _editSideEffectsReminderHours(BuildContext context, int currentValue) {
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        int value = currentValue;
+        return AlertDialog(
+          title: const Text('Promemoria effetti collaterali'),
+          content: StatefulBuilder(
+            builder: (context, setState) => RadioGroup<int>(
+              groupValue: value,
+              onChanged: (v) => setState(() => value = v!),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [2, 4, 6, 8]
+                    .map(
+                      (n) => RadioListTile<int>(
+                        title: Text('$n ore dopo l\'iniezione'),
+                        value: n,
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Annulla'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+                ref
+                    .read(notificationSettingsProvider.notifier)
+                    .setSideEffectsReminderHours(value);
               },
               child: const Text('Salva'),
             ),

--- a/lib/models/injection_record.dart
+++ b/lib/models/injection_record.dart
@@ -13,6 +13,7 @@ class InjectionRecord {
     this.notes = '',
     this.sideEffects = const [],
     this.calendarEventId = '',
+    this.customPointLabel,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -26,6 +27,7 @@ class InjectionRecord {
   final String notes;
   final List<String> sideEffects;
   final String calendarEventId;
+  final String? customPointLabel;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -50,8 +52,8 @@ class InjectionRecord {
   /// Get point code (e.g., "CD-3")
   String get pointCode => '$zoneCode-$pointNumber';
 
-  /// Get point label (e.g., "Coscia Dx · 3")
-  String get pointLabel => '$zoneName · $pointNumber';
+  /// Get point label (e.g., "Coscia Dx · 3") — uses custom label if set
+  String get pointLabel => customPointLabel ?? '$zoneName · $pointNumber';
 
   /// Get emoji for zone
   String get emoji => switch (zoneId) {
@@ -79,6 +81,7 @@ class InjectionRecord {
       notes: json['notes'] as String? ?? '',
       sideEffects: (json['sideEffects'] as String?)?.split(',').where((s) => s.isNotEmpty).toList() ?? [],
       calendarEventId: json['calendarEventId'] as String? ?? '',
+      customPointLabel: json['customPointLabel'] as String?,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
     );
@@ -97,6 +100,7 @@ class InjectionRecord {
     'notes': notes,
     'sideEffects': sideEffects.join(','),
     'calendarEventId': calendarEventId,
+    'customPointLabel': customPointLabel,
     'createdAt': createdAt.toIso8601String(),
     'updatedAt': updatedAt.toIso8601String(),
   };
@@ -112,6 +116,7 @@ class InjectionRecord {
     String? notes,
     List<String>? sideEffects,
     String? calendarEventId,
+    String? customPointLabel,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) => InjectionRecord(
@@ -124,6 +129,7 @@ class InjectionRecord {
     notes: notes ?? this.notes,
     sideEffects: sideEffects ?? this.sideEffects,
     calendarEventId: calendarEventId ?? this.calendarEventId,
+    customPointLabel: customPointLabel ?? this.customPointLabel,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
@@ -133,11 +139,13 @@ class InjectionRecord {
     required int zoneId,
     required int pointNumber,
     required DateTime scheduledAt,
+    String? customPointLabel,
   }) => InjectionRecord(
     zoneId: zoneId,
     pointNumber: pointNumber,
     scheduledAt: scheduledAt,
     status: InjectionStatus.scheduled,
+    customPointLabel: customPointLabel,
     createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
   );

--- a/pages/index.html
+++ b/pages/index.html
@@ -315,12 +315,12 @@
       <div class="lang" data-lang="it">
         <h2 class="section-title">Changelog</h2>
         <div class="card kcard">
-          <h3>Versione 4.4.0 (4 mar 2026)</h3>
+          <h3>Versione 4.5.0 (4 mar 2026)</h3>
           <ul style="margin: 8px 0 0; padding-left: 18px; color: var(--muted); font-size: 14px;">
-            <li><strong>Backup completo (JSON)</strong>: Esporta e ripristina tutte le tabelle del database in un unico file JSON</li>
-            <li><strong>Due strategie di import</strong>: "Sostituisci tutto" o "Unisci" per aggiungere dati senza sovrascrivere</li>
-            <li><strong>Fix posizioni personalizzate</strong>: Le coordinate dei punti personalizzate non vengono più perse al riavvio dell'app</li>
-            <li><strong>Migrazione database v2</strong>: Nuova colonna per proteggere le personalizzazioni dal reset automatico</li>
+            <li><strong>Nomi personalizzati ovunque</strong>: I nomi custom dei punti ora appaiono nel calendario, storico, notifiche, export CSV/PDF e report medico</li>
+            <li><strong>Promemoria 1 minuto</strong>: Notifica urgente 1 minuto prima dell'iniezione</li>
+            <li><strong>Promemoria effetti collaterali</strong>: Notifica configurabile dopo il completamento per registrare effetti collaterali</li>
+            <li><strong>Export CSV migliorato</strong>: Aggiunta colonna label con nome personalizzato del punto</li>
           </ul>
           <p style="margin-top: 12px; font-size: 13px;">
             <a href="https://github.com/WaYdotNET/inje-care-plan/blob/main/CHANGELOG.md">Vedi lo storico completo su
@@ -331,12 +331,12 @@
       <div class="lang" data-lang="en">
         <h2 class="section-title">Changelog</h2>
         <div class="card kcard">
-          <h3>Version 4.4.0 (Mar 4, 2026)</h3>
+          <h3>Version 4.5.0 (Mar 4, 2026)</h3>
           <ul style="margin: 8px 0 0; padding-left: 18px; color: var(--muted); font-size: 14px;">
-            <li><strong>Full backup (JSON)</strong>: Export and restore all database tables in a single JSON file</li>
-            <li><strong>Two import strategies</strong>: "Replace all" or "Merge" to add data without overwriting existing records</li>
-            <li><strong>Custom position fix</strong>: Custom point coordinates are no longer lost on app restart</li>
-            <li><strong>Database migration v2</strong>: New column to protect customizations from automatic reset</li>
+            <li><strong>Custom names everywhere</strong>: Custom point names now appear in calendar, history, notifications, CSV/PDF export, and medical reports</li>
+            <li><strong>1-minute reminder</strong>: Urgent notification 1 minute before injection</li>
+            <li><strong>Side effects reminder</strong>: Configurable notification after completion to log side effects</li>
+            <li><strong>Improved CSV export</strong>: Added label column with custom point name</li>
           </ul>
           <p style="margin-top: 12px; font-size: 13px;">
             <a href="https://github.com/WaYdotNET/inje-care-plan/blob/main/CHANGELOG.md">View full history on GitHub</a>
@@ -355,7 +355,7 @@
           Autore: <a href="https://waydotnet.com">waydotnet.com</a>
         </p>
         <p style="margin: 0">
-          Licenza: GPL-3.0 · InjeCare Plan v4.4.0 © 2024–2026 Carlo Bertini (WaYdotNET)
+          Licenza: GPL-3.0 · InjeCare Plan v4.5.0 © 2024–2026 Carlo Bertini (WaYdotNET)
         </p>
       </div>
       <div class="lang" data-lang="en">
@@ -365,7 +365,7 @@
           Author: <a href="https://waydotnet.com">waydotnet.com</a>
         </p>
         <p style="margin: 0">
-          License: GPL-3.0 · InjeCare Plan v4.4.0 © 2024–2026 Carlo Bertini (WaYdotNET)
+          License: GPL-3.0 · InjeCare Plan v4.5.0 © 2024–2026 Carlo Bertini (WaYdotNET)
         </p>
       </div>
     </div>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: injecare_plan
 description: InjeCare Plan - La tua terapia, sotto controllo.
 publish_to: 'none'
-version: 4.4.0+3
+version: 4.5.0+4
 homepage: https://waydotnet.com
 repository: https://github.com/WaYdotNET/inje-care-plan
 


### PR DESCRIPTION
## Summary
- Custom point names now propagated everywhere: calendar, history, notifications, CSV/PDF export, medical report
- Added 1-minute pre-injection reminder and configurable side effects reminder (4h post-completion)
- Side effects dialog deferred to next injection recording
- CSV export includes label column (backward-compatible import)
- Bumped to v4.5.0+4, updated changelog and website

## Files changed
- `lib/models/injection_record.dart` — added `customPointLabel` field
- `lib/features/injection/injection_repository.dart` — added `resolvePointLabel()` 
- `lib/features/injection/record_screen.dart` — resolve label before creating record
- `lib/features/home/home_minimal_screen.dart` — resolve labels in dialogs and auto-fill
- `lib/core/services/export_service.dart` — CSV with label column
- `lib/core/services/import_service.dart` — supports 4 and 5-column CSV
- `lib/core/services/pdf_report_service.dart` — Punto column shows full label
- `lib/core/services/notification_service.dart` — 1-min reminder + side effects reminder
- `lib/core/services/notification_settings_provider.dart` — sideEffectsReminderHours
- `lib/core/widgets/side_effects_dialog.dart` — new reusable dialog
- `lib/features/settings/settings_screen.dart` — side effects settings UI
- `lib/features/calendar/calendar_screen.dart` — side effects from calendar

## Test plan
- [x] `flutter analyze` — zero new issues
- [x] `flutter test` — all tests pass (exit code 0)
- [ ] Manual: customize point name → create injection → verify custom name in calendar/history
- [ ] Manual: complete injection → verify side effects reminder notification after 4h

🤖 Generated with [Claude Code](https://claude.com/claude-code)